### PR TITLE
don't call SizeOf for type parameters

### DIFF
--- a/checkers/hugeParam_checker.go
+++ b/checkers/hugeParam_checker.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-critic/go-critic/checkers/internal/astwalk"
 	"github.com/go-critic/go-critic/framework/linter"
+	"golang.org/x/exp/typeparams"
 )
 
 func init() {
@@ -49,6 +50,9 @@ func (c *hugeParamChecker) checkParams(params []*ast.Field) {
 	for _, p := range params {
 		for _, id := range p.Names {
 			typ := c.ctx.TypeOf(id)
+			if _, ok := typ.(*typeparams.TypeParam); ok {
+				continue
+			}
 			size := c.ctx.SizesInfo.Sizeof(typ)
 			if size >= c.sizeThreshold {
 				c.warn(id, size)

--- a/checkers/rangeValCopy_checker.go
+++ b/checkers/rangeValCopy_checker.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-critic/go-critic/checkers/internal/astwalk"
 	"github.com/go-critic/go-critic/framework/linter"
+	"golang.org/x/exp/typeparams"
 )
 
 func init() {
@@ -63,6 +64,9 @@ func (c *rangeValCopyChecker) VisitStmt(stmt ast.Stmt) {
 	}
 	typ := c.ctx.TypeOf(rng.Value)
 	if typ == nil {
+		return
+	}
+	if _, ok := typ.(*typeparams.TypeParam); ok {
 		return
 	}
 	if size := c.ctx.SizesInfo.Sizeof(typ); size >= c.sizeThreshold {

--- a/checkers/testdata/hugeParam/negative_tests_go118.go
+++ b/checkers/testdata/hugeParam/negative_tests_go118.go
@@ -1,0 +1,6 @@
+//go:build go1.18
+// +build go1.18
+
+package checker_test
+
+func genericFunc[T comparable](x T) {}

--- a/checkers/testdata/rangeValCopy/negative_tests_go118.go
+++ b/checkers/testdata/rangeValCopy/negative_tests_go118.go
@@ -1,0 +1,11 @@
+//go:build go1.18
+// +build go1.18
+
+package checker_test
+
+func genericSlice[T any](original []T, f func(T)) {
+	for _, v := range original {
+		// OK: v is a type parameter.
+		f(v)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/quasilyte/go-ruleguard v0.3.16-0.20220213074421-6aa060fab41a
 	github.com/quasilyte/go-ruleguard/dsl v0.3.21
 	github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95
+	golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/tools v0.1.9-0.20211228192929-ee1ca4ffc4da
 )


### PR DESCRIPTION
StdSizes.SizeOf method doesn't support type parameters. https://github.com/golang/go/blob/78b722d8c2f764c3048c6f0344e9ebcd2687813d/src/go/types/sizes.go#L156-L159

sdsdFixes go-critic/go-critic#1223